### PR TITLE
Change to the provisional server and the API

### DIFF
--- a/back-end/provisional-server.py
+++ b/back-end/provisional-server.py
@@ -12,13 +12,7 @@ def main(config_path):
     @app.route('/')
     @app.route('/<path:path>')
     def root(path = ''):
-        #TODO: Add a better solution to prevent XSS.
-        #This is low priority, because the server will only ever be in this mode for short periods of time and 30 characters is low enough to prevent a lot of XSS.
-        if len(path) < 30:
-            response = make_response(f"You tried to access {path}, but the server is not ready yet. Try again later.")
-        else:
-            response = make_response(f"You tried to access a site, but the server is not ready yet. Try again later.")
-
+        response = make_response(f"You tried to access a site, but the server is not ready yet. Try again later.")
         response.status_code = 503
 
         return response

--- a/back-end/server/api/core.py
+++ b/back-end/server/api/core.py
@@ -10,6 +10,8 @@ def authenticate(req, device_index, require_admin=False) -> RegisteredDevice:
     device_id = req.args.get('deviceId')
     if device_id is None:
         json_data = req.json
+        if not json_data:
+            return None
         device_id = json_data.get('deviceId')
 
     device = device_index.devices.get(device_id)

--- a/back-end/server/api/core.py
+++ b/back-end/server/api/core.py
@@ -55,6 +55,10 @@ def create_core_blueprint(device_index: DeviceIndex, vote_index: VoteIndex):
     @bp.route('/all-votes', methods=['POST'])
     def get_all_votes():
         """Gets all votes."""
+        device = authenticate(request, device_index)
+        if not device:
+            abort(403)
+            
         return jsonify([vote['vote'] for vote in vote_index.votes.values()])
 
     @bp.route('/vote', methods=['POST'])
@@ -88,11 +92,17 @@ def create_core_blueprint(device_index: DeviceIndex, vote_index: VoteIndex):
     @bp.route('/user-id', methods=['POST'])
     def get_user_id():
         device = authenticate(request, device_index)
+        if not device:
+            abort(403)
+            
         return jsonify(device.user_id)
 
     @bp.route('/unregister-user', methods=['POST'])
     def unregister_user():
         device = authenticate(request, device_index)
+        if not device:
+            abort(403)
+            
         device_index.unregister_user(device.user_id)
         return jsonify({})
 


### PR DESCRIPTION
The provisional server no longer echoes the path back to the user, this prevents XSS that was previously barely accounted for.
The API now aborts with a 403 on any requests that aren't used for login, this accounts for some potential internal server errors and the APIs internal inconsistency with page access.